### PR TITLE
Restrict exposed Minecraft ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     ports:
       - "25565:25565/tcp"
       - "19132:19132/udp"
-      - "25575:25575"
-      - "8123:8123"
     env_file:
       - .env
     networks:


### PR DESCRIPTION
## Summary
- remove host publishing for the RCON port 25575
- remove host publishing for the BlueMap port 8123
- keep Java and Bedrock/Geyser gameplay ports exposed

## Validation
- docker compose config --quiet